### PR TITLE
A0-2305: Disable clippy arg lint

### DIFF
--- a/ink-wrapper/src/main.rs
+++ b/ink-wrapper/src/main.rs
@@ -319,7 +319,7 @@ fn define_reader(message: &MessageSpec<PortableForm>, metadata: &InkProject) -> 
 
     quote! {
         $(docs(message.docs()))
-        #[allow(dead_code)]
+        #[allow(dead_code, clippy::too_many_arguments)]
         pub async fn $(message.label())<E, C: ink_wrapper_types::Connection<E>>(
             &self,
             $(conn): &C, $(message_args(message.args(), metadata))
@@ -341,7 +341,7 @@ fn define_mutator(message: &MessageSpec<PortableForm>, metadata: &InkProject) ->
 
     quote! {
         $(docs(message.docs()))
-        #[allow(dead_code)]
+        #[allow(dead_code, clippy::too_many_arguments)]
         pub async fn $(message.label())<TxInfo, E, C: ink_wrapper_types::SignedConnection<TxInfo, E>>(
             &self, $(conn): &C,
             $(message_args(message.args(), metadata))


### PR DESCRIPTION
Disables `clippy::too_many_arguments` for contract read/mutate methods.