### PR TITLE
Fix incorrect codegen on event fields with generic types

### DIFF
--- a/ink-wrapper/src/codegen.rs
+++ b/ink-wrapper/src/codegen.rs
@@ -400,13 +400,12 @@ fn type_ref(id: u32, metadata: &InkProject) -> String {
 /// The `prefix` is prepended to the type name if the type is a custom type.
 fn type_ref_prefix(id: u32, metadata: &InkProject, prefix: &str) -> String {
     let typ = resolve(metadata, id);
-    let generic_prefix = if typ.is_custom() { prefix } else { "" };
 
     match &typ.type_def {
         TypeDef::Primitive(primitive) => type_ref_primitive(primitive),
         TypeDef::Tuple(tuple) => type_ref_tuple(tuple, metadata, prefix),
-        TypeDef::Composite(_) => type_ref_generic(typ, metadata, generic_prefix),
-        TypeDef::Variant(_) => type_ref_generic(typ, metadata, generic_prefix),
+        TypeDef::Composite(_) => type_ref_generic(typ, metadata, prefix),
+        TypeDef::Variant(_) => type_ref_generic(typ, metadata, prefix),
         TypeDef::Array(array) => type_ref_array(array, metadata, prefix),
         TypeDef::Sequence(sequence) => type_ref_sequence(sequence, metadata, prefix),
         TypeDef::Compact(compact) => type_ref_compact(compact, metadata, prefix),
@@ -429,7 +428,8 @@ fn type_ref_generic(typ: &Type<PortableForm>, metadata: &InkProject, prefix: &st
         generics.push_str(&type_ref_prefix(param.ty.unwrap().id, metadata, prefix));
     }
 
-    format!("{}{}<{}>", prefix, typ.qualified_name(), generics)
+    let generic_prefix = if typ.is_custom() { prefix } else { "" };
+    format!("{}{}<{}>", generic_prefix, typ.qualified_name(), generics)
 }
 
 /// Generates a type reference to a primitive type.

--- a/test-project/src/test_contract_tests.rs
+++ b/test-project/src/test_contract_tests.rs
@@ -142,7 +142,8 @@ async fn test_events() -> Result<()> {
                 a: 123,
                 b: struct2.clone(),
                 c: struct1.c,
-                d: (struct1, struct2)
+                d: (struct1.clone(), struct2),
+                e: Some(struct1),
             })
     );
     assert!(events[1] == Ok(Event::Event2 {}));

--- a/test-project/test_contract/lib.rs
+++ b/test-project/test_contract/lib.rs
@@ -31,6 +31,7 @@ mod test_contract {
         b: Struct2,
         c: [u64; 4],
         d: (Struct1, Struct2),
+        e: Option<Struct1>,
     }
 
     #[ink(event)]
@@ -260,6 +261,7 @@ mod test_contract {
                 b: self.struct2_val,
                 c: self.struct1_val.c,
                 d: (self.struct1_val, self.struct2_val),
+                e: Some(self.struct1_val),
             });
             Self::env().emit_event(Event2 {});
         }


### PR DESCRIPTION
Hello :) hope Ya'll don't mind the PR, found this issue while applying ink-wrapper to one of my contracts

On the generation of code for an event with a field that mixed:

  1. Non-user defined generic (e.g. `Option<T>`)
  2. User-defined generic parameter (e.g. `T = CustomStruct`)

The generation fails to prefix the user-defined parameter with `super::`.

This can be seen in these tests I performed while debugging, given this event:

```rs
#[derive(scale::Decode, scale::Encode)]
#[cfg_attr(...)]
pub struct CustomId(u32);

#[derive(scale::Decode, scale::Encode)]
#[cfg_attr(...)]
pub struct CustomGeneric<T> {
    val: T
}

#[ink(event)]
pub struct SomeEvent {
    val1: Option<CustomId>,
    val2: CustomGeneric<CustomId>,
    val3: (CustomId, Option<CustomId>),
    val4: Vec<CustomId>,
    val5: Vec<Option<CustomId>>,
    val6: Result<u32, CustomId>,
}
```

ink-wrapper compiled using the main branch generated this code (errors explained in the comments):

```rs
#[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
pub struct CustomId(pub u32);

#[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
pub struct CustomGeneric {
    pub val: CustomId,
}

pub mod event {
    #[allow(dead_code, clippy::large_enum_variant)]
    #[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
    pub enum Event {
        SomeEvent {
            val1: Option<CustomId>, // <- failed to prefix with super::,
            val2: super::CustomGeneric<super::CustomId>,
            val3: (super::CustomId, Option<CustomId>), // <- failed to prefix .1 with super::,
            val4: Vec<super::CustomId>,
            val5: Vec<Option<CustomId>>, // <- failed to prefix with super::,
            val6: Result<u32, CustomId>, // <- failed to prefix with super::,
        },
    }
}
```

and this is the generated code after applying this PR:

```rs
#[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
pub struct CustomId(pub u32);

#[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
pub struct CustomGeneric {
    pub val: CustomId,
}

pub mod event {
    #[allow(dead_code, clippy::large_enum_variant)]
    #[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
    pub enum Event {
        SomeEvent {
            val1: Option<super::CustomId>,
            val2: super::CustomGeneric<super::CustomId>,
            val3: (super::CustomId, Option<super::CustomId>),
            val4: Vec<super::CustomId>,
            val5: Vec<Option<super::CustomId>>,
            val6: Result<u32, super::CustomId>,
        },
    }
}
```

The problem resided in the code assuming that if the generic was not custom, then its parameters were also not custom, which may not always be the case.

I'm not familiar w/ the codebase so I may have broken something else without realizing. But all the tests I performed resulted in correctly compiled code. Let me know if I missed anything :)