### PR TITLE
Use v4 action checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run all checks
         run: make all-dockerized

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: Cardinal-Cryptography/aleph-node/.github/actions/install-rust-toolchain@5eda3cd85e7e3aec3f2db7a26631c65d52c4b9ea
       - uses: './.github/actions/publish-if-newer'
         with:


### PR DESCRIPTION
node16 is deprecated and it seems that action/checkout@v2{3} use it. This comes up as a warning but the CI complains about the lack of job `build-and-test` which is untrue. Bumping the ver to see if the warning is obfuscating the real reason.

https://github.com/Cardinal-Cryptography/ink-wrapper/actions/runs/7698864527/workflow